### PR TITLE
Updates Provider versions

### DIFF
--- a/.github/workflows/code-quality-terraform.yml
+++ b/.github/workflows/code-quality-terraform.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  TERRAFORM_VERSION: 0.12.20
+  TERRAFORM_VERSION: 0.13.2
   TERRAFORM_ACTIONS_COMMENT: true
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.4 (2020-06-11)
+# 1.1.4 (2020-06-11)
 
 * Updates documentation and examples (#9) ([9d3dfd7](https://github.com/operatehappy/terraform-aws-s3-bucket/commit/9d3dfd7)), closes [#9](https://github.com/operatehappy/terraform-aws-s3-bucket/issues/9)
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add the module to your Terraform resources like so:
 ```hcl
 module "simple_example" {
   source  = "operatehappy/s3-bucket/aws"
-  version = "1.1.4"
+  version = "1.2.0"
 
   name = "oh-demo-simple-example"
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## Requirements
 
-This module requires Terraform version `0.12.20` or newer.
+This module requires Terraform version `0.13.0` or newer.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ Additional usage examples are available in the `examples` directory via [GitHub]
 | acceleration_status | Acceleration Status of S3 Bucket | `string` | n/a |
 | name | Name of S3 Bucket | `string` | n/a |
 | policy | Policy (JSON) Document of S3 Bucket | `string` | n/a |
-| region | Region of S3 Bucket | `string` | n/a |
 | acl | Canned ACL of S3 Bucket | `string` | `"private"` |
 | cors_rule | Map of CORS Rules of S3 Bucket | `any` | `{}` |
 | create_readme | Toggle creation of `README.md` in root of S3 Bucket | `bool` | `true` |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This module depends on a correctly configured [AWS Provider](https://www.terrafo
 Add the module to your Terraform resources like so:
 
 ```hcl
-module "simple-example" {
+module "simple_example" {
   source  = "operatehappy/s3-bucket/aws"
   version = "1.1.4"
 

--- a/examples/complex/README.md
+++ b/examples/complex/README.md
@@ -20,7 +20,7 @@ A _complex_ configuration of the `terraform-aws-s3-bucket` Module could look lik
 
 ```hcl
 // create S3 Bucket to be used as logging target
-module "complex-example-target" {
+module "complex_example_target" {
   source  = "operatehappy/s3-bucket/aws"
   version = "1.1.4"
   name    = "oh-demos-complex-example-target"
@@ -32,7 +32,7 @@ module "complex-example-target" {
   }]
 }
 
-module "complex-example" {
+module "complex_example" {
   source  = "operatehappy/s3-bucket/aws"
   version = "1.1.4"
 

--- a/examples/complex/README.md
+++ b/examples/complex/README.md
@@ -22,7 +22,7 @@ A _complex_ configuration of the `terraform-aws-s3-bucket` Module could look lik
 // create S3 Bucket to be used as logging target
 module "complex_example_target" {
   source  = "operatehappy/s3-bucket/aws"
-  version = "1.1.4"
+  version = "1.2.0"
   name    = "oh-demos-complex-example-target"
   acl     = "log-delivery-write"
 
@@ -34,7 +34,7 @@ module "complex_example_target" {
 
 module "complex_example" {
   source  = "operatehappy/s3-bucket/aws"
-  version = "1.1.4"
+  version = "1.2.0"
 
   name = "oh-demos-complex-example"
 

--- a/examples/complex/main.tf
+++ b/examples/complex/main.tf
@@ -1,6 +1,6 @@
 module "complex_example_target" {
   source  = "operatehappy/s3-bucket/aws"
-  version = "1.1.4"
+  version = "1.2.0"
   name    = "oh-demos-complex-example-target"
   acl     = "log-delivery-write"
 
@@ -12,7 +12,7 @@ module "complex_example_target" {
 
 module "complex_example" {
   source  = "operatehappy/s3-bucket/aws"
-  version = "1.1.4"
+  version = "1.2.0"
 
   name = "oh-demos-complex-example"
 

--- a/examples/complex/main.tf
+++ b/examples/complex/main.tf
@@ -1,4 +1,4 @@
-module "complex-example-target" {
+module "complex_example_target" {
   source  = "operatehappy/s3-bucket/aws"
   version = "1.1.4"
   name    = "oh-demos-complex-example-target"
@@ -10,7 +10,7 @@ module "complex-example-target" {
   }]
 }
 
-module "complex-example" {
+module "complex_example" {
   source  = "operatehappy/s3-bucket/aws"
   version = "1.1.4"
 

--- a/examples/logging/README.md
+++ b/examples/logging/README.md
@@ -22,14 +22,14 @@ A _logging_ configuration of the `terraform-aws-s3-bucket` Module could look lik
 // create S3 Bucket to be used as logging target
 module "logging_example_target" {
   source  = "operatehappy/s3-bucket/aws"
-  version = "1.1.4"
+  version = "1.2.0"
   name    = "oh-demos-logging-example-target"
   acl     = "log-delivery-write"
 }
 
 module "logging_example" {
   source  = "operatehappy/s3-bucket/aws"
-  version = "1.1.4"
+  version = "1.2.0"
 
   name = "oh-demos-logging-example"
 

--- a/examples/logging/README.md
+++ b/examples/logging/README.md
@@ -20,14 +20,14 @@ A _logging_ configuration of the `terraform-aws-s3-bucket` Module could look lik
 
 ```hcl
 // create S3 Bucket to be used as logging target
-module "logging-example-target" {
+module "logging_example_target" {
   source  = "operatehappy/s3-bucket/aws"
   version = "1.1.4"
   name    = "oh-demos-logging-example-target"
   acl     = "log-delivery-write"
 }
 
-module "logging-example" {
+module "logging_example" {
   source  = "operatehappy/s3-bucket/aws"
   version = "1.1.4"
 

--- a/examples/logging/main.tf
+++ b/examples/logging/main.tf
@@ -1,13 +1,13 @@
 module "logging_example_target" {
   source  = "operatehappy/s3-bucket/aws"
-  version = "1.1.4"
+  version = "1.2.0"
   name    = "oh-demos-logging-example-target"
   acl     = "log-delivery-write"
 }
 
 module "logging_example" {
   source  = "operatehappy/s3-bucket/aws"
-  version = "1.1.4"
+  version = "1.2.0"
 
   name = "oh-demos-logging-example"
 

--- a/examples/logging/main.tf
+++ b/examples/logging/main.tf
@@ -1,11 +1,11 @@
-module "logging-example-target" {
+module "logging_example_target" {
   source  = "operatehappy/s3-bucket/aws"
   version = "1.1.4"
   name    = "oh-demos-logging-example-target"
   acl     = "log-delivery-write"
 }
 
-module "logging-example" {
+module "logging_example" {
   source  = "operatehappy/s3-bucket/aws"
   version = "1.1.4"
 

--- a/examples/object-lock-configuration/README.md
+++ b/examples/object-lock-configuration/README.md
@@ -19,7 +19,7 @@ For a list of installation instructions, see the [Readme document](https://regis
 An _object-lock_ configuration of the `terraform-aws-s3-bucket` Module could look like this:
 
 ```hcl
-module "object-lock-configuration-example" {
+module "object_lock_configuration_example" {
   source  = "operatehappy/s3-bucket/aws"
   version = "1.1.4"
 

--- a/examples/object-lock-configuration/README.md
+++ b/examples/object-lock-configuration/README.md
@@ -21,7 +21,7 @@ An _object-lock_ configuration of the `terraform-aws-s3-bucket` Module could loo
 ```hcl
 module "object_lock_configuration_example" {
   source  = "operatehappy/s3-bucket/aws"
-  version = "1.1.4"
+  version = "1.2.0"
 
   name = "oh-demos-object-lock-configuration-example"
 

--- a/examples/object-lock-configuration/main.tf
+++ b/examples/object-lock-configuration/main.tf
@@ -1,6 +1,6 @@
 module "object_lock_configuration_example" {
   source  = "operatehappy/s3-bucket/aws"
-  version = "1.1.4"
+  version = "1.2.0"
 
   name = "oh-demos-object-lock-configuration-example"
 

--- a/examples/object-lock-configuration/main.tf
+++ b/examples/object-lock-configuration/main.tf
@@ -1,4 +1,4 @@
-module "object-lock-configuration-example" {
+module "object_lock_configuration_example" {
   source  = "operatehappy/s3-bucket/aws"
   version = "1.1.4"
 

--- a/examples/server-side-encryption/README.md
+++ b/examples/server-side-encryption/README.md
@@ -21,7 +21,7 @@ A _server-side-encryption_ configuration of the `terraform-aws-s3-bucket` Module
 ```hcl
 module "server_side_encryption_example" {
   source  = "operatehappy/s3-bucket/aws"
-  version = "1.1.4"
+  version = "1.2.0"
 
   name   = "oh-demos-server-side-encryption-example"
 

--- a/examples/server-side-encryption/README.md
+++ b/examples/server-side-encryption/README.md
@@ -19,7 +19,7 @@ For a list of installation instructions, see the [Readme document](https://regis
 A _server-side-encryption_ configuration of the `terraform-aws-s3-bucket` Module could look like this:
 
 ```hcl
-module "server-side-encryption-example" {
+module "server_side_encryption_example" {
   source  = "operatehappy/s3-bucket/aws"
   version = "1.1.4"
 

--- a/examples/server-side-encryption/main.tf
+++ b/examples/server-side-encryption/main.tf
@@ -1,6 +1,6 @@
 module "server_side_encryption_example" {
   source  = "operatehappy/s3-bucket/aws"
-  version = "1.1.4"
+  version = "1.2.0"
 
   name = "oh-demos-server-side-encryption-example"
 

--- a/examples/server-side-encryption/main.tf
+++ b/examples/server-side-encryption/main.tf
@@ -1,4 +1,4 @@
-module "server-side-encryption-example" {
+module "server_side_encryption_example" {
   source  = "operatehappy/s3-bucket/aws"
   version = "1.1.4"
 

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -19,7 +19,7 @@ For a list of installation instructions, see the [Readme document](https://regis
 A _simple_ configuration of the `terraform-aws-s3-bucket` Module could look like this:
 
 ```hcl
-module "simple-example" {
+module "simple_example" {
   source  = "operatehappy/s3-bucket/aws"
   version = "1.1.4"
 

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -21,7 +21,7 @@ A _simple_ configuration of the `terraform-aws-s3-bucket` Module could look like
 ```hcl
 module "simple_example" {
   source  = "operatehappy/s3-bucket/aws"
-  version = "1.1.4"
+  version = "1.2.0"
 
   name = "oh-demo-simple-example"
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,4 +1,4 @@
-module "simple-example" {
+module "simple_example" {
   source  = "operatehappy/s3-bucket/aws"
   version = "1.1.4"
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,6 +1,6 @@
 module "simple_example" {
   source  = "operatehappy/s3-bucket/aws"
-  version = "1.1.4"
+  version = "1.2.0"
 
   name = "oh-demos-simple-example"
 

--- a/examples/versioning/README.md
+++ b/examples/versioning/README.md
@@ -21,7 +21,7 @@ A _versioning_ configuration of the `terraform-aws-s3-bucket` Module could look 
 ```hcl
 module "versioning_example" {
   source  = "operatehappy/s3-bucket/aws"
-  version = "1.1.4"
+  version = "1.2.0"
 
   name   = "oh-demos-versioning-example"
 

--- a/examples/versioning/README.md
+++ b/examples/versioning/README.md
@@ -19,7 +19,7 @@ For a list of installation instructions, see the [Readme document](https://regis
 A _versioning_ configuration of the `terraform-aws-s3-bucket` Module could look like this:
 
 ```hcl
-module "versioning-example" {
+module "versioning_example" {
   source  = "operatehappy/s3-bucket/aws"
   version = "1.1.4"
 

--- a/examples/versioning/main.tf
+++ b/examples/versioning/main.tf
@@ -1,6 +1,6 @@
 module "versioning_example" {
   source  = "operatehappy/s3-bucket/aws"
-  version = "1.1.4"
+  version = "1.2.0"
 
   name = "oh-demos-versioning-example"
 

--- a/examples/versioning/main.tf
+++ b/examples/versioning/main.tf
@@ -1,4 +1,4 @@
-module "versioning-example" {
+module "versioning_example" {
   source  = "operatehappy/s3-bucket/aws"
   version = "1.1.4"
 

--- a/examples/website/README.md
+++ b/examples/website/README.md
@@ -19,7 +19,7 @@ For a list of installation instructions, see the [Readme document](https://regis
 A _website_ configuration of the `terraform-aws-s3-bucket` Module could look like this:
 
 ```hcl
-module "website-example" {
+module "website_example" {
   source  = "operatehappy/s3-bucket/aws"
   version = "1.1.4"
 

--- a/examples/website/README.md
+++ b/examples/website/README.md
@@ -21,7 +21,7 @@ A _website_ configuration of the `terraform-aws-s3-bucket` Module could look lik
 ```hcl
 module "website_example" {
   source  = "operatehappy/s3-bucket/aws"
-  version = "1.1.4"
+  version = "1.2.0"
 
   name   = "oh-demos-website-example"
 

--- a/examples/website/main.tf
+++ b/examples/website/main.tf
@@ -1,6 +1,6 @@
 module "website_example" {
   source  = "operatehappy/s3-bucket/aws"
-  version = "1.1.4"
+  version = "1.2.0"
 
   name = "oh-demos-website-example"
 

--- a/examples/website/main.tf
+++ b/examples/website/main.tf
@@ -1,10 +1,10 @@
-module "website-example" {
+module "website_example" {
   source  = "operatehappy/s3-bucket/aws"
   version = "1.1.4"
 
   name = "oh-demos-website-example"
 
-  website = [{
+  website = {
     index_document           = "index.html"
     error_document           = "error.html"
     routing_rules            = <<EOF
@@ -18,7 +18,7 @@ module "website-example" {
     }]
     EOF
     redirect_all_requests_to = null
-  }]
+  }
 
   cors_rule = {
     allowed_headers = ["*"]

--- a/main.tf
+++ b/main.tf
@@ -102,8 +102,6 @@ resource "aws_s3_bucket" "bucket" {
 
   acceleration_status = var.acceleration_status
 
-  region = var.region
-
   request_payer = var.request_payer
 
   // replication_configuration will be added in a future release

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws      = ">= 3.4.0"
-    template = "> 2.0.0"
+    aws      = "~> 3.4"
+    template = "~> 2.0"
   }
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    template = "> 1.0.0"
     aws      = ">= 3.4.0"
+    template = "> 2.0.0"
   }
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws      = "> 2.10.0"
     template = "> 1.0.0"
+    aws      = ">= 3.4.0"
   }
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.20"
+  required_version = ">= 0.13.0"
 
   required_providers {
     aws      = "> 2.10.0"

--- a/variables.tf
+++ b/variables.tf
@@ -82,12 +82,6 @@ variable "request_payer" {
   default     = "BucketOwner"
 }
 
-variable "region" {
-  type        = string
-  description = "Region of S3 Bucket"
-  default     = null
-}
-
 variable "server_side_encryption_configuration" {
   type        = map
   description = "Server-side Encryption (SSE) Configuration of S3 Bucket"


### PR DESCRIPTION
This PR switches the base Terraform version from `0.12.20` to `0.13.x` and updates the AWS Provider to `3.4.0`.

I've also updated the examples to use underscores (`_`) instead of dashes (`-`) to separate resource names. This brings the code more in line with current best practices.

I intend to release this as module version `1.2.0`.